### PR TITLE
Use Infernal_jll instead of single-platform artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,8 +1,0 @@
-[[Infernal]]
-arch = "x86_64"
-os = "linux"
-git-tree-sha1 = "672d01f66aef593490f77957a7de4080285821d4"
-
-    [[Infernal.download]]
-    url = "http://eddylab.org/infernal/infernal-1.1.4-linux-intel-gcc.tar.gz"
-    sha256 = "372b4ee045915c34e7ba0d7c16d019a4f495c895fbd01f1aff1acc0045fd5704"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,8 @@ authors = ["Andrea Di Gioacchino", "Jorge Fernandez-de-Cossio-Diaz <j.cossio.dia
 version = "0.1.0"
 
 [deps]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Infernal_jll = "5109d7c4-8f61-540a-bdd6-fb9d06080a8f"
 
 [compat]
 julia = "1.6"
+Infernal_jll = "1.1"

--- a/src/Infernal.jl
+++ b/src/Infernal.jl
@@ -1,7 +1,5 @@
 module Infernal
 
-using Pkg: @artifact_str
-
 include("cmd.jl")
 
 end

--- a/src/cmd.jl
+++ b/src/cmd.jl
@@ -1,9 +1,11 @@
+import Infernal_jll
+
 """
     path(name)
 
 Path to Infernal binary `name`.
 """
-path(name::String) = joinpath(artifact"Infernal", "infernal-1.1.4-linux-intel-gcc", "binaries", name)
+path(name::String) = joinpath(Infernal_jll.artifact_dir, "bin", name)
 
 """
     cmd(name, [args...])


### PR DESCRIPTION
The minimal changes to use Infernal_jll instead of the single-platform binary artifact.

Note: i couldn't run the complete tests as the download of the `Rfam.cm.gz` always errors out on the bad internet connection i'm currently on and doesn't reconnect but starts anew, never finishing the download. Placing the file in the correct scratchspace dir after manually downloading the file with `wget --continue` doesn't seem to help either.

The following works:
```
isfile(Infernal.path("cmalign"))
Infernal.exe("cmalign", "-h")
Infernal.exe("easel", "-h")
```

